### PR TITLE
Parse command line params more nicely

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,18 @@ git clone https://github.com/danieljharvey/tmux-mate`
 cd tmux-mate
 
 # install tmux-mate using Haskell Stack (install instructions here: https://docs.haskellstack.org/en/stable/install_and_upgrade/)
-# this will put tmux-mate-exe in your path
+# this will put tmux-mate in your path
 stack install
 
-# curse this terrible env var based API for passing config files and run tmux-mate
-export TMUX_MATE_PATH='./samples/Sample1.dhall && tmux-mate-exe
+# run tmux-mate, passing it a path to your dhall config file
+tmux-mate ./samples/Sample1.dhall
 ```
 
 You should now see a `tmux` window running two infinite loops (that will soon wear your battery down, apologies). What if it turns out we need more things in our development environment?
 
 ```bash
 # Run tmux-mate with the second sample script
-export TMUX_MATE_PATH='./samples/Sample2.dhall && tmux-mate-exe
+tmux-mate ./samples/Sample2.dhall
 ```
 
 You will now see your same session with an extra window added. `tmux-mate` has diffed the two sessions and added/removed the changes. This might seem like a useless optimization when running a trivial process like `yes`, but when running multiple build environments this saves loads of time.

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,18 +1,20 @@
 module Main where
 
-import System.Environment
+import Options.Applicative
 import System.Exit
 import TmuxMate
 
 main :: IO ()
 main = do
-  path <- lookupEnv "TMUX_MATE_PATH"
-  case path of
-    Just dhallPath -> do
-      didItWork <- loadTestSession dhallPath
-      case didItWork of
-        Yeah -> exitWith ExitSuccess
-        Nah i -> exitWith (ExitFailure i)
-    Nothing -> do
-      putStrLn "Pass a valid path to TMUX_MATE_PATH pls"
-      exitWith (ExitFailure 1)
+  options' <- execParser (info options fullDesc)
+  didItWork <- loadTestSession (configPath options')
+  case didItWork of
+    Yeah -> exitWith ExitSuccess
+    Nah i -> exitWith (ExitFailure i)
+
+data Options
+  = Options {configPath :: String}
+  deriving (Eq, Ord, Show)
+
+options :: Parser Options
+options = Options <$> argument str (metavar "<path-to-config-file>")

--- a/package.yaml
+++ b/package.yaml
@@ -30,7 +30,7 @@ library:
     - dhall
 
 executables:
-  tmux-mate-exe:
+  tmux-mate:
     main: Main.hs
     source-dirs: app
     ghc-options:
@@ -39,6 +39,7 @@ executables:
       - -with-rtsopts=-N
     dependencies:
       - tmux-mate
+      - optparse-applicative
 
 tests:
   tmux-mate-test:


### PR DESCRIPTION
Env vars are dead! Long live `optparse-applicative`! Addresses #2 