### PR TITLE
tmux-mate init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ brew update && brew install danieljharvey/tools/tmux-mate
 
 Binaries available on the [releases](https://github.com/danieljharvey/tmux-mate/releases) page.
 
+### Getting started
+
+```bash
+# create a default tmux-mate.dhall
+tmux-mate init
+# Start running everything
+tmux-mate start
+```
+
 ### Tutorial
 
 Let's grab a couple of sample config files...

--- a/app/CLICommands.hs
+++ b/app/CLICommands.hs
@@ -1,0 +1,7 @@
+module CLICommands where
+
+import TmuxMate (CLIOptions (..))
+
+data CLICommand
+  = CLIRun CLIOptions
+  | CLIInit

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,29 +1,51 @@
 module Main where
 
-import Options.Applicative
+import Options.Applicative ((<|>))
+import qualified Options.Applicative as Opt
 import System.Exit
 import TmuxMate
 
 main :: IO ()
 main = do
-  options' <- execParser (info options fullDesc)
-  didItWork <- loadTestSession options'
-  case didItWork of
-    Yeah -> exitWith ExitSuccess
-    Nah i -> exitWith (ExitFailure i)
+  command' <- Opt.execParser (Opt.info command Opt.fullDesc)
+  case command' of
+    CLIInit -> do
+      createTmuxMateDhall
+      putStrLn "Initial tmux-mate.dhall created!"
+    CLIRun options' -> do
+      didItWork <- loadTestSession options'
+      case didItWork of
+        Yeah -> exitWith ExitSuccess
+        Nah i -> exitWith (ExitFailure i)
 
-configFilePathParser :: Parser ConfigFilePath
+configFilePathParser :: Opt.Parser ConfigFilePath
 configFilePathParser =
   ConfigFilePath
-    <$> argument str (metavar "<path-to-config-file>")
+    <$> Opt.argument Opt.str (Opt.metavar "<path-to-config-file>")
 
-verbosityParser :: Parser Verbosity
+verbosityParser :: Opt.Parser Verbosity
 verbosityParser =
-  flag' Chatty (short 'v' <> long "verbose")
-    <|> flag' DryRun (short 'd' <> long "dry-run")
+  Opt.flag' Chatty (Opt.short 'v' <> Opt.long "verbose")
+    <|> Opt.flag' DryRun (Opt.short 'd' <> Opt.long "dry-run")
     <|> pure Silent
 
-options :: Parser CLIOptions
+options :: Opt.Parser CLIOptions
 options =
   CLIOptions
     <$> configFilePathParser <*> verbosityParser
+
+command :: Opt.Parser CLICommand
+command =
+  otherCommands
+    <|> (CLIRun <$> options)
+
+otherCommands :: Opt.Parser CLICommand
+otherCommands =
+  Opt.subparser
+    ( Opt.command
+        "init"
+        ( Opt.info
+            (pure CLIInit)
+            (Opt.progDesc "Initialise a new tmux-mate.dhall file")
+        )
+    )

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,6 +1,7 @@
 module Main where
 
-import Options.Applicative ((<|>))
+import CLICommands
+import Options (command)
 import qualified Options.Applicative as Opt
 import System.Exit
 import TmuxMate
@@ -17,37 +18,3 @@ main = do
       case didItWork of
         Yeah -> exitWith ExitSuccess
         Nah i -> exitWith (ExitFailure i)
-
-configFilePathParser :: Opt.Parser (Maybe ConfigFilePath)
-configFilePathParser =
-  ( Just <$> ConfigFilePath
-      <$> Opt.argument Opt.str (Opt.metavar "<path-to-config-file>")
-  )
-    <|> pure Nothing
-
-verbosityParser :: Opt.Parser Verbosity
-verbosityParser =
-  Opt.flag' Chatty (Opt.short 'v' <> Opt.long "verbose")
-    <|> Opt.flag' DryRun (Opt.short 'd' <> Opt.long "dry-run")
-    <|> pure Silent
-
-options :: Opt.Parser CLIOptions
-options =
-  CLIOptions
-    <$> configFilePathParser <*> verbosityParser
-
-command :: Opt.Parser CLICommand
-command =
-  otherCommands
-    <|> (CLIRun <$> options)
-
-otherCommands :: Opt.Parser CLICommand
-otherCommands =
-  Opt.subparser
-    ( Opt.command
-        "init"
-        ( Opt.info
-            (pure CLIInit)
-            (Opt.progDesc "Initialise a new tmux-mate.dhall file")
-        )
-    )

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -18,10 +18,12 @@ main = do
         Yeah -> exitWith ExitSuccess
         Nah i -> exitWith (ExitFailure i)
 
-configFilePathParser :: Opt.Parser ConfigFilePath
+configFilePathParser :: Opt.Parser (Maybe ConfigFilePath)
 configFilePathParser =
-  ConfigFilePath
-    <$> Opt.argument Opt.str (Opt.metavar "<path-to-config-file>")
+  ( Just <$> ConfigFilePath
+      <$> Opt.argument Opt.str (Opt.metavar "<path-to-config-file>")
+  )
+    <|> pure Nothing
 
 verbosityParser :: Opt.Parser Verbosity
 verbosityParser =

--- a/app/Options.hs
+++ b/app/Options.hs
@@ -1,0 +1,46 @@
+module Options (command) where
+
+import CLICommands
+import Options.Applicative ((<|>))
+import qualified Options.Applicative as Opt
+import TmuxMate
+
+command :: Opt.Parser CLICommand
+command =
+  otherCommands
+    <|> (CLIRun <$> options)
+
+configFilePathParser :: Opt.Parser (Maybe ConfigFilePath)
+configFilePathParser =
+  ( Just <$> ConfigFilePath
+      <$> Opt.argument Opt.str (Opt.metavar "<path-to-config-file>")
+  )
+    <|> pure Nothing
+
+verbosityParser :: Opt.Parser Verbosity
+verbosityParser =
+  Opt.flag' Chatty (Opt.short 'v' <> Opt.long "verbose")
+    <|> Opt.flag' DryRun (Opt.short 'd' <> Opt.long "dry-run")
+    <|> pure Silent
+
+options :: Opt.Parser CLIOptions
+options =
+  CLIOptions
+    <$> configFilePathParser <*> verbosityParser
+
+otherCommands :: Opt.Parser CLICommand
+otherCommands =
+  Opt.subparser
+    ( Opt.command
+        "init"
+        ( Opt.info
+            (pure CLIInit)
+            (Opt.progDesc "Initialise a new tmux-mate.dhall file")
+        )
+        <> Opt.command
+          "start"
+          ( Opt.info
+              (CLIRun <$> options)
+              (Opt.progDesc "Start running everything in the selected config file")
+          )
+    )

--- a/src/TmuxMate.hs
+++ b/src/TmuxMate.hs
@@ -5,14 +5,17 @@ module TmuxMate
   ( loadTestSession,
     DidItWork (..),
     CLIOptions (..),
+    CLICommand (..),
     ConfigFilePath (..),
     Verbosity (..),
+    createTmuxMateDhall,
   )
 where
 
 import qualified Dhall as Dhall
 import System.Process
 import TmuxMate.Commands
+import TmuxMate.Init
 import TmuxMate.Logger
 import TmuxMate.Running
 import TmuxMate.TmuxCommands

--- a/src/TmuxMate.hs
+++ b/src/TmuxMate.hs
@@ -5,7 +5,6 @@ module TmuxMate
   ( loadTestSession,
     DidItWork (..),
     CLIOptions (..),
-    CLICommand (..),
     ConfigFilePath (..),
     Verbosity (..),
     createTmuxMateDhall,

--- a/src/TmuxMate.hs
+++ b/src/TmuxMate.hs
@@ -12,6 +12,7 @@ module TmuxMate
   )
 where
 
+import Data.Maybe (fromMaybe)
 import qualified Dhall as Dhall
 import System.Process
 import TmuxMate.Commands
@@ -39,7 +40,7 @@ data DidItWork
 loadTestSession :: CLIOptions -> IO DidItWork
 loadTestSession options = do
   let (decoder :: Dhall.Decoder Session) = Dhall.auto
-  let path = getConfigFilePath $ configFilePath options
+  let path = fromMaybe "tmux-mate.dhall" (getConfigFilePath <$> configFilePath options)
       myLog = logger (verbosity options)
   config <- Dhall.detailed (Dhall.inputFile decoder path)
   case parseSession config of

--- a/src/TmuxMate/Init.hs
+++ b/src/TmuxMate/Init.hs
@@ -1,0 +1,37 @@
+module TmuxMate.Init (createTmuxMateDhall) where
+
+-- where we make a new empty session file
+
+import Data.Text.IO
+import Dhall
+import Dhall.Core (pretty)
+import TmuxMate.Types
+  ( Pane (..),
+    PaneArrangement (..),
+    PaneCommand (..),
+    Session (..),
+    SessionName (..),
+    Window (..),
+    WindowName (..),
+  )
+
+createTmuxMateDhall :: IO ()
+createTmuxMateDhall = do
+  let dhallVal = pretty (embed inject defaultSession)
+  Data.Text.IO.writeFile "./tmux-mate.dhall" dhallVal
+
+defaultSession :: Session
+defaultSession =
+  Session
+    (SessionName "tmux-mate")
+    [ Window
+        (WindowName "first")
+        [ Pane
+            ( PaneCommand "watch echo \"hello from tmux-mate\""
+            ),
+          Pane
+            ( PaneCommand "watch echo \"hello again from tmux-mate\""
+            )
+        ]
+        (PaneArrangement "tiled")
+    ]

--- a/src/TmuxMate/Types.hs
+++ b/src/TmuxMate/Types.hs
@@ -164,10 +164,6 @@ newtype ConfigFilePath
   = ConfigFilePath {getConfigFilePath :: String}
   deriving (Eq, Ord, Show)
 
-data CLICommand
-  = CLIRun CLIOptions
-  | CLIInit
-
 data CLIOptions
   = CLIOptions
       { configFilePath :: Maybe ConfigFilePath,

--- a/src/TmuxMate/Types.hs
+++ b/src/TmuxMate/Types.hs
@@ -164,6 +164,10 @@ newtype ConfigFilePath
   = ConfigFilePath {getConfigFilePath :: String}
   deriving (Eq, Ord, Show)
 
+data CLICommand
+  = CLIRun CLIOptions
+  | CLIInit
+
 data CLIOptions
   = CLIOptions
       { configFilePath :: ConfigFilePath,

--- a/src/TmuxMate/Types.hs
+++ b/src/TmuxMate/Types.hs
@@ -170,7 +170,7 @@ data CLICommand
 
 data CLIOptions
   = CLIOptions
-      { configFilePath :: ConfigFilePath,
+      { configFilePath :: Maybe ConfigFilePath,
         verbosity :: Verbosity
       }
   deriving (Eq, Ord, Show)


### PR DESCRIPTION
This adds a `tmux-mate init` command that creates a default `tmux-mate.dhall` file in the current folder.

It also makes the file path optional, so just running `tmux-mate` will try and run `tmux-mate tmux-mate.dhall`.